### PR TITLE
Save config out of game directory.

### DIFF
--- a/Nucleus/Files/Filesystem.cs
+++ b/Nucleus/Files/Filesystem.cs
@@ -48,7 +48,7 @@ public static class Filesystem
 				// See also: https://jimrich.sk/environment-specialfolder-on-windows-linux-and-os-x/
 				var PlatformApplicationDataPath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
 				var PlatformApplicationDataSearchPath = new DiskSearchPath(PlatformApplicationDataPath);
-				cfg = AddSearchPath("cfg", DiskSearchPath.Combine(PlatformApplicationDataSearchPath, "CloneDash"));
+				cfg = AddSearchPath("cfg", DiskSearchPath.Combine(PlatformApplicationDataSearchPath, EngineCore.GameInfo.GameName));
 			}
 			var assets = AddSearchPath("assets", DiskSearchPath.Combine(game, "assets"));
 			{


### PR DESCRIPTION
Some platforms, such as Linux, we like install game to a non-writable path like `/usr/lib/clonedash`, creating a `cfg` directory in it is not possible for normal user.

This patch use `<game>/cfg` if it exists for compatibility reason, else, we save config to `Environment.SpecialFolder.ApplicationData`, which value depends OS. See comment in source code for more info.