### PR TITLE
Do not open assets for writing.

### DIFF
--- a/CloneDash/Compatibility/MuseDash/Init.cs
+++ b/CloneDash/Compatibility/MuseDash/Init.cs
@@ -43,7 +43,7 @@ namespace CloneDash.Compatibility.MuseDash
 			Interlude.Spin(submessage: "Muse Dash Compat: Platform initialized...");
 
 			using (StaticSequentialProfiler.StartStackFrame("Mount to Filesystem")) {
-				using (Stream stream = Filesystem.Open("assets", "mdlut.dat") ?? throw new Exception("Cannot find the mdlut.dat file"))
+				using (Stream stream = Filesystem.Open("assets", "mdlut.dat", FileAccess.Read, FileMode.Open) ?? throw new Exception("Cannot find the mdlut.dat file"))
 					StreamingAssets = Filesystem.AddSearchPath("musedash", new UnitySearchPath(Path.Combine(WhereIsMuseDashDataFolder!, $"StreamingAssets/aa/{StandalonePlatform}"), stream));
 			}
 


### PR DESCRIPTION
Some platforms, such as Linux, we like install game to a non-writable path like `/usr/lib/clonedash`, opening assets for writing is not possible for normal user.

Changing it to read only seems fine, at least does not break playing official maps.