### PR TITLE
Refactor `SteamGames` and fix steam discovery for newly installed games

### DIFF
--- a/CloneDash.Common/Compatibility/Valve/SteamGames.cs
+++ b/CloneDash.Common/Compatibility/Valve/SteamGames.cs
@@ -4,93 +4,87 @@
 using Microsoft.Win32;
 #endif
 
-namespace CloneDash.Common.Compatibility.Valve;
-
-public static class SteamGames
+namespace CloneDash.Common.Compatibility.Valve
 {
-	public static string? WhereIsSteamInstalled() {
+	public static class SteamGames
+	{
+		private const string SteamRegistryPath = @"HKEY_LOCAL_MACHINE\SOFTWARE\Valve\Steam";
+		private const string SteamRegistryPathAlt = @"HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432NODE\Valve\Steam";
+		private const string SteamRegistryInstallPathKey = "InstallPath";
+
+		public static string? WhereIsSteamInstalled() {
 #if COMPILED_WINDOWS
-		// Where is Steam installed?
-#pragma warning disable CA1416 // Validate platform compatibility
-		string? steamInstallPath = Registry.GetValue("HKEY_LOCAL_MACHINE\\SOFTWARE\\Valve\\Steam", "InstallPath", null) as string;
-		if (steamInstallPath == null) { // Sometimes the install path will be here instead
-			steamInstallPath = Registry.GetValue("HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432NODE\\Valve\\Steam", "InstallPath", null) as string;
-			if (steamInstallPath == null)
-				return null;
-		}
-#pragma warning restore CA1416 // Validate platform compatibility
-		return steamInstallPath;
+			string? steamInstallPath =
+				Registry.GetValue(SteamRegistryPath, SteamRegistryInstallPathKey, null) as string
+				?? Registry.GetValue(SteamRegistryPathAlt, SteamRegistryInstallPathKey, null) as string; //Sometimes the installation path will be here instead
+
+			return steamInstallPath;
 
 #elif COMPILED_OSX
-		// Where is Steam installed?
 		string homeDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-		string steamPath = Path.Combine(homeDirectory, "Library", "Application Support", "Steam", "steamapps", "libraryfolders.vdf");
+		string steamPath = Path.Combine(homeDirectory, "Library", "Application Support", "Steam");
 		return Directory.Exists(steamPath) ? steamPath : null;
 
 #elif COMPILED_LINUX
-		// Where is Steam installed?
 		string home = Environment.GetEnvironmentVariable("HOME")!;
 		string steamClassicInstallPath = Path.Combine(home, ".local", "share", "Steam");
 		string steamFlatpakInstallPath = Path.Combine(home, ".var", "app", "com.valvesoftware.Steam", ".local", "share", "Steam");
 
-		string? steamInstallPath = Directory.Exists(steamClassicInstallPath) ? steamClassicInstallPath : Directory.Exists(steamFlatpakInstallPath) ? steamFlatpakInstallPath : null;
-		if (steamInstallPath == null)
-			return null;
-		return steamInstallPath;
+		if (Directory.Exists(steamClassicInstallPath))
+			return steamClassicInstallPath;
+		if (Directory.Exists(steamFlatpakInstallPath))
+			return steamFlatpakInstallPath;
+		return null;
 #else
 #error Please implement WhereIsSteamInstalled on this platform
-return null;
 #endif
-	}
-	public static string? WhereIsGameInstalled(ulong steamAppID) {
-		string? steamInstallPath = WhereIsSteamInstalled();
-		if (steamInstallPath == null)
+		}
+
+		private static IEnumerable<(string Path, ValveDataFile.VDFDict? Apps)> GetLibraryFolders(string steamInstallPath) {
+			string libraryFoldersPath = Path.Combine(steamInstallPath, "steamapps", "libraryfolders.vdf");
+			if (!File.Exists(libraryFoldersPath))
+				yield break;
+
+			ValveDataFile libraryFolders = ValveDataFile.FromFile(libraryFoldersPath);
+			foreach (KeyValuePair<string, ValveDataFile.VDFItem> vdfItemPair in libraryFolders["libraryfolders"]) {
+				string path = vdfItemPair.Value.GetString("path");
+
+				ValveDataFile.VDFDict? apps = vdfItemPair.Value["apps"] as ValveDataFile.VDFDict;
+				yield return (path, apps);
+			}
+		}
+
+
+		private static string? FindGameInLibrary(string libraryPath, ValveDataFile.VDFDict? apps, string appId) {
+			string manifestPath = Path.Combine(libraryPath, "steamapps", $"appmanifest_{appId}.acf");
+
+			bool foundViaCache = apps != null && apps.Contains(appId);
+			bool foundViaManifestFile = File.Exists(manifestPath); //Fallback. `apps` is just a cache and sometimes doesn't include recently installed or updated games
+
+			if (!foundViaCache && !foundViaManifestFile)
+				return null;
+
+			ValveDataFile appManifest = ValveDataFile.FromFile(manifestPath);
+			string installDir = appManifest["AppState"].GetString("installdir");
+
+			return Path.Combine(libraryPath, "steamapps", "common", installDir);
+		}
+
+
+		public static string? WhereIsGameInstalled(ulong steamAppId) {
+			string? steamInstallPath = WhereIsSteamInstalled();
+			if (steamInstallPath == null)
+				return null;
+
+			string appId = steamAppId.ToString();
+
+			foreach ((string libraryPath, ValveDataFile.VDFDict? apps) in GetLibraryFolders(steamInstallPath)) {
+				string? installDir = FindGameInLibrary(libraryPath, apps, appId);
+				if (installDir != null)
+					return installDir;
+			}
+
 			return null;
-
-		string game_appid = "" + steamAppID;
-		string game_installdir = "";
-		bool game_installed = false;
-
-#if COMPILED_WINDOWS
-		ValveDataFile games = ValveDataFile.FromFile(steamInstallPath + "\\steamapps\\libraryfolders.vdf");
-		
-		foreach (KeyValuePair<string, ValveDataFile.VDFItem> vdfItemPair in games["libraryfolders"]) {
-			var apps = (vdfItemPair.Value["apps"] as ValveDataFile.VDFDict)!;
-			if (apps.Contains(game_appid)) {
-				ValveDataFile appManifest = ValveDataFile.FromFile(vdfItemPair.Value.GetString("path") + $"\\steamapps\\appmanifest_{game_appid}.acf");
-				game_installed = true;
-				game_installdir = vdfItemPair.Value.GetString("path") + "\\steamapps\\common\\" + appManifest["AppState"].GetString("installdir");
-			}
 		}
-#elif COMPILED_OSX
-		ValveDataFile games = ValveDataFile.FromFile(steamInstallPath);
-
-		foreach (KeyValuePair<string, ValveDataFile.VDFItem> vdfItemPair in games["libraryfolders"]) {
-			var apps = (vdfItemPair.Value["apps"] as ValveDataFile.VDFDict)!;
-			if (apps.Contains(game_appid)) {
-				ValveDataFile appManifest = ValveDataFile.FromFile(Path.Combine(vdfItemPair.Value.GetString("path"), "steamapps", $"appmanifest_{game_appid}.acf"));
-				game_installed = true;
-				game_installdir = Path.Combine(vdfItemPair.Value.GetString("path"), "steamapps", "common", appManifest["AppState"].GetString("installdir"));
-			}
-		}
-#elif COMPILED_LINUX
-		ValveDataFile games = ValveDataFile.FromFile(Path.Combine(steamInstallPath, "steamapps", "libraryfolders.vdf"));
-
-		foreach (KeyValuePair<string, ValveDataFile.VDFItem> vdfItemPair in games["libraryfolders"]) {
-			var apps = (vdfItemPair.Value["apps"] as ValveDataFile.VDFDict)!;
-			if (apps.Contains(game_appid)) {
-				ValveDataFile appManifest = ValveDataFile.FromFile(Path.Combine(vdfItemPair.Value.GetString("path"), "steamapps", $"appmanifest_{game_appid}.acf"));
-				game_installed = true;
-				game_installdir = Path.Combine(vdfItemPair.Value.GetString("path"), "steamapps", "common", appManifest["AppState"].GetString("installdir"));
-			}
-		}
-#else
-#error Please implement WhereIsGameInstalled on this platform
-return null;
-#endif
-
-		if (!game_installed)
-			return null;
-		return game_installdir;
 	}
 }


### PR DESCRIPTION
Hi! This PR refactors the `SteamGames` class and fixes few bugs
- In `WhereIsSteamInstalled()` the OSX platform was returning `libraryfolders.vdf` directly instead of steam folder like all other platforms
- Added fallback for to checking `apps` in the valve data file by checking if the manifest file exists directly because `apps` is just a cache that takes a while to update especially after recently installing the or updating a game

Took me good while to figure this one out from random steam threads and github issues but yeah 😅
Also while I was fixing this I combined lot of the logic to be general since it was lot of repeating code

