### PR TITLE
Search for attachments in all skins

### DIFF
--- a/Nucleus/Models/Runtime.cs
+++ b/Nucleus/Models/Runtime.cs
@@ -355,6 +355,15 @@ public class ModelInstance : IContainsSetupPose, IModelInterface<BoneInstance, S
 
 		if (Data.DefaultSkin?.TryGetAttachment(slot, name, out attachment) ?? false)
 			return attachment;
+		
+		foreach (Skin skin in Data.Skins)
+		{
+			if (skin == Data.DefaultSkin || skin == Skin)
+				continue; // we already checked these
+			
+			if (skin.TryGetAttachment(slot, name, out attachment))
+				return attachment;
+		}
 
 		return null;
 	}


### PR DESCRIPTION
feels like a bit of a band-aid fix but I am not knowledgeable enough about models to do this proper

fixes specifically amiya's mainshow model (she has two extra skins: "normal" and "reverse", I do not know what they are used for, but they contain the arm/leg attachments) by looping over all the remaining skins and searching the attachments in there

| previous | pr |
|---|---|
|<img width="715" height="851" alt="image" src="https://github.com/user-attachments/assets/e79fd1e5-7c34-4302-a666-3b017c3a5cd8" />|<img width="676" height="787" alt="image" src="https://github.com/user-attachments/assets/49ee9701-0be0-41d5-881d-fa265429a0c6" />|

rhodes island finally got enough funding to undo amiya's amputations